### PR TITLE
Remove Celsius conversion from extended properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CAS 번호별로 분자식, 분자량, LogP 등 기본 정보를 `cas_numbers_pr
 python fetch_extended_properties.py
 ```
 
-분자량, 끓는점, 녹는점, 밀도, log Kow 등을 수집하여 `cas_numbers_property_table_v2.csv`로 저장합니다. 화씨나 켈빈으로 표시된 온도는 자동으로 섭씨로 변환됩니다.
+분자량, 끓는점, 녹는점, 밀도, log Kow 등을 수집하여 `cas_numbers_property_table_v2.csv`로 저장합니다. 온도는 웹사이트에 표시된 단위를 그대로 기록합니다.
 
 
 ### 클러스터링 예제

--- a/fetch_extended_properties.py
+++ b/fetch_extended_properties.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import re
 import requests
 from bs4 import BeautifulSoup
 import pubchempy as pcp
@@ -33,21 +32,6 @@ def _find_first_string(obj):
                 return result
     return None
 
-def _temp_to_celsius(value: str) -> float | None:
-    """Extract numeric temperature and convert to °C."""
-    if not value:
-        return None
-    m = re.search(r"(-?\d+(?:\.\d+)?)", value)
-    if not m:
-        return None
-    temp = float(m.group(1))
-    text = value.lower()
-    if "f" in text and "°f" in text:
-        return (temp - 32) * 5 / 9
-    if "k" in text and (" k" in text or text.endswith("k")):
-        return temp - 273.15
-    # default assume Celsius
-    return temp
 
 def _pug_view_value(cid: int, heading: str):
     url = f"https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/data/compound/{cid}/JSON?heading={heading.replace(' ', '%20')}"
@@ -76,13 +60,9 @@ def get_pubchem_data(cas: str):
         mp = _pug_view_value(cid, 'Melting Point')
         dens = _pug_view_value(cid, 'Density')
         if bp:
-            c = _temp_to_celsius(bp)
-            if c is not None:
-                data['BoilingPoint'] = c
+            data['BoilingPoint'] = bp.strip()
         if mp:
-            c = _temp_to_celsius(mp)
-            if c is not None:
-                data['MeltingPoint'] = c
+            data['MeltingPoint'] = mp.strip()
         if dens:
             data['Density'] = dens
     except Exception as e:
@@ -122,13 +102,9 @@ def get_nist_data(cas: str):
             value = tds[1].get_text(strip=True)
             units = tds[2].get_text(strip=True)
             if 'Tboil' in label and 'BoilingPoint' not in data:
-                c = _temp_to_celsius(f"{value} {units}")
-                if c is not None:
-                    data['BoilingPoint'] = c
+                data['BoilingPoint'] = f"{value} {units}".strip()
             elif 'Tfus' in label and 'MeltingPoint' not in data:
-                c = _temp_to_celsius(f"{value} {units}")
-                if c is not None:
-                    data['MeltingPoint'] = c
+                data['MeltingPoint'] = f"{value} {units}".strip()
     except Exception as e:
         print(f"NIST lookup failed for {cas}: {e}")
     return data


### PR DESCRIPTION
## Summary
- fetch raw temperature values from PubChem and NIST without converting to Celsius
- remove unused conversion helper
- update README to reflect new behaviour

## Testing
- `python -m py_compile fetch_extended_properties.py fetch_properties.py cluster_substances.py`
- `pip install -r requirements.txt`
- `python fetch_extended_properties.py` *(fails: Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684cdd23f74c8324ade3a3ce4c4cc941